### PR TITLE
Add category retrieval functionality and update API endpoints

### DIFF
--- a/Arryn_Back/infrastructure/api/urls.py
+++ b/Arryn_Back/infrastructure/api/urls.py
@@ -1,9 +1,20 @@
 from django.urls import path
 from .views import (
-    ArchivosJsonView, DetallesAdicionalesView, DetallesPorIdView, 
-    getUsers, createUser, userDetail, BrandListView, OffersByCategoryView,
-    BestPricesView, PriceComparisonView, RankedOffersView, TrendingOffersView,
-    StoreComparisonReportView, PriceAnalysisReportView
+    ArchivosJsonView,
+    DetallesAdicionalesView,
+    DetallesPorIdView,
+    getUsers,
+    createUser,
+    userDetail,
+    BrandListView,
+    CategoryListView,
+    OffersByCategoryView,
+    BestPricesView,
+    PriceComparisonView,
+    RankedOffersView,
+    TrendingOffersView,
+    StoreComparisonReportView,
+    PriceAnalysisReportView,
 )
 
 urlpatterns = [
@@ -14,6 +25,7 @@ urlpatterns = [
     path("archivos/detalles/", DetallesAdicionalesView.as_view(), name="detalles_all"),
     path("archivos/<str:id>/detalles/", DetallesPorIdView.as_view(), name="detalles_por_id"),
     path("brands/", BrandListView.as_view(), name="brand-list"),
+    path("categories/", CategoryListView.as_view(), name="category-list"),
     path("offers/<str:category>/", OffersByCategoryView.as_view(), name="offers_by_category"),
     
     # Nuevas funcionalidades

--- a/Arryn_Back/infrastructure/api/views.py
+++ b/Arryn_Back/infrastructure/api/views.py
@@ -8,7 +8,14 @@ from pymongo import ASCENDING
 
 from .models import User
 from .serializer import UserSerializer
-from ...domain.services.mongo_service import guardar_json, obtener_json, obtener_por_id, obtener_marcas, db
+from ...domain.services.mongo_service import (
+    guardar_json,
+    obtener_json,
+    obtener_por_id,
+    obtener_marcas,
+    obtener_categorias,
+    db,
+)
 from ...domain.services.parse_details import parse_details
 from ...domain.services.price_service import PricePersonalizationService
 from ...domain.services.ranking_service import OfferRankingService
@@ -160,6 +167,23 @@ class BrandListView(APIView):
         if with_counts:
             payload["counts"] = counts
         return Response(payload, status=status.HTTP_200_OK)
+
+class CategoryListView(APIView):
+    def get(self, request):
+        try:
+            categories = obtener_categorias("archivos")
+            return Response(
+                {
+                    "count": len(categories),
+                    "categories": categories,
+                },
+                status=status.HTTP_200_OK,
+            )
+        except Exception as e:
+            return Response(
+                {"error": f"Error obteniendo categorías: {e}"},
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            )
 
 
 class OffersByCategoryView(APIView):


### PR DESCRIPTION
This pull request adds support for retrieving a distinct, normalized, and alphabetically sorted list of product categories from the database, and exposes this functionality via a new API endpoint. The changes include the implementation of a new service function, the addition of a corresponding API view, and updates to the URL configuration to register the new endpoint.

**New category listing functionality:**

* Added the `obtener_categorias` function to `mongo_service.py` to fetch distinct categories from the database, normalize them for case and whitespace differences, and return them in alphabetical order. This function also provides a fallback list when the database is unavailable.
* Created the `CategoryListView` API view in `views.py` to handle GET requests for the new categories endpoint, returning the count and list of categories.
* Updated `urls.py` to register the new `categories/` endpoint, mapped to `CategoryListView`.

**Code organization improvements:**

* Updated import statements in `views.py` to include the new `obtener_categorias` function, improving maintainability and clarity.
* Refactored import formatting in `urls.py` for better readability and added the `CategoryListView` import.